### PR TITLE
GNU Make

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # Psion3-Wari
 This game was released as freeware in 1997. The code is now made available for those interested in such things.
+
+## Compiling Wari
+
+You will need:
+
+- **DOS:** A DOS computer, VM or emulator (tested with DOSBox Staging 0.81.0)
+- **SDK:** Psion SIBO C SDK 2.20
+- **Compiler:** JPI/Clarion TopSpeed C 3.10
+- **Make:** Either of the following.
+  - GNU Make for DOS (from DJGPP - tested with 4.4) with the latest version of `CWSDPMI.EXE`
+  - Borland Make (tested with 3.6)
+
+### Using GNU Make
+```batch
+make
+```
+
+### Using Borland Make
+```batch
+make -fwari.mak
+```
+

--- a/code/Makefile
+++ b/code/Makefile
@@ -1,0 +1,159 @@
+#* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+#* Project: WA  WARI GAME FOR PSION 3a       *  Written by: Nick Matthews  *
+#*  Module: WARI FOR PSION SIBOSDK/TOPSPEED  *  Date Started:  9 Jul 1996  *
+#*    File: MAKEFILE    Type: GNU MAKEFILE   *  Date Revised: 16 MAR 2024  *
+#* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+
+INC=C:\\sibosdk\\include
+PRJ=wari
+CC=tscx
+
+%.obj: %.c
+	$(CC) $*.c /fp$(PRJ).pr
+
+%.g: %.cat
+	ctran $* -e$(INC)\\ -g -s -v
+	copy $*.g $(INC)
+
+%.rsc: %.rss
+	rcomp $*.rss -o$*.rsc -i$(INC)\\ -g$*.rsg -v
+
+%.rsg: %.rss
+	rcomp $*.rss -o$*.rsc -i$(INC)\\ -g$*.rsg -v
+
+%.rg: %.re
+	rgprep $*.re $*.rex
+	lprep -i$(INC)\\ -o$*.i $*.rex
+	del $*.rex
+	rgcomp $*.i $*.rg
+	del $*.i
+	copy $*.rg $(INC)
+
+%.rzc: %.rsc
+	rchuf hwim -v -i$*.rsc -o$*.rzc
+
+%.rhi: %.rht
+	phcomp $*.rht -v -l
+
+%.shd: %.ms
+	makeshd $*.ms
+
+%.pic: %.pcx
+	wspcx -p $*.pcx
+
+
+#######################################################################
+
+wari.app : wari.img
+	copy wari.img wari.app
+
+wari.img : wari.obj warimain.obj waridraw.obj warimove.obj \
+           wari.afl wari.pic wari.rzc wari.shd wari.pr
+	$(CC) /L wari.pr
+	del wari.exe
+
+wari.afl :
+	echo wari.pic>  wari.afl
+	echo wari.rzc>> wari.afl
+	echo wari.shd>> wari.afl
+
+wari.ms :
+	echo Wari>  wari.ms
+	echo.>>     wari.ms
+	echo 1000>> wari.ms
+
+wari.plk :
+	echo wari24.pic>  wari.plk
+	echo wari48.pic>> wari.plk
+
+wari.pic : wari.plk wari24.pic wari48.pic
+	wspcx -L wari.plk
+
+wari24.pic : wari24.pcx
+wari48.pic : wari48.pcx
+
+wari.obj : wari.cat wari.g
+	ctran wari -e$(INC)\\ -c -s -v
+	$(CC) wari.c /fp$(PRJ).pr
+	ecobj wari.obj
+
+wari.g : wari.cat
+
+warihelp.rhi : warihelp.rht
+
+wari.rsg : wari.rss wari.rg warihelp.rhi
+
+wari.rsc : wari.rss wari.rg warihelp.rhi
+
+wari.rg : wari.re wari.g
+
+wari.rzc : wari.rsc
+
+wari.shd : wari.ms
+
+warimain.obj : warimain.c wari.g wari.rsg wari.h warimove.h
+waridraw.obj : waridraw.c wari.h
+warimove.obj : warimove.c warimove.h
+
+
+#---------------------------------[ Clean ]--------------------------------#
+
+clean :
+	del WARI24.PIC
+	del WARI48.PIC
+	del WARI.AFL
+	del WARI.APP
+	del WARI.C
+	del WARIDRAW.OBJ
+	del WARI.G
+	del WARIHELP.RHI
+	del WARI.IMG
+	del WARIMAIN.OBJ
+	del WARI.MAP
+	del WARIMOVE.OBJ
+	del WARI.MS
+	del WARI.OBJ
+	del WARI.PH
+	del WARI.PIC
+	del WARI.PLK
+	del WARI.RG
+	del WARI.RSC
+	del WARI.RSG
+	del WARI.RZC
+	del WARI.SHD
+
+
+#-------------------------------[ Final zip ]------------------------------#
+
+zip : war_prel.zip
+
+war_prel.zip : wari.app readme.txt
+	if exist war_prel.zip del war_prel.zip
+	pkzip war_prel.zip wari.app readme.txt
+
+
+#------------------------------[ Backup zip ]------------------------------#
+
+backup : waribu.rsp
+	pkzip j:\backup\war_pbu.zip -u @waribu.rsp
+
+waribu.rsp :
+	echo files.txt    >  waribu.rsp
+	echo Makefile     >> waribu.rsp
+	echo wari.mak     >> waribu.rsp
+	echo wari.pr      >> waribu.rsp
+	echo wari.cat     >> waribu.rsp
+	echo wari.h       >> waribu.rsp
+	echo warimain.c   >> waribu.rsp
+	echo waridraw.c   >> waribu.rsp
+	echo warimove.h   >> waribu.rsp
+	echo warimove.c   >> waribu.rsp
+	echo wari.re      >> waribu.rsp
+	echo wari.rss     >> waribu.rsp
+	echo warihelp.rht >> waribu.rsp
+	echo wari24.pcx   >> waribu.rsp
+	echo wari48.pcx   >> waribu.rsp
+	echo readme.txt   >> waribu.rsp
+
+# End of WARI.MAK file


### PR DESCRIPTION
Added a GNU Makefile, removing the need for Borland Make. Also updated the README with a (very brief) explanation of how to compile it.

I used the Wari source code to test a project I'm working on (recreating CTRAN, the Psion OO C preprocessor). You are one of the few people who wrote apps using the OO extensions and released the code!

Unfortunately there's an issue using my new CTRAN with Borland Make, so I converted the original makefile to work with GNU Make for DOS (from the DJGPP project).